### PR TITLE
register_helper: accept multiple helpers as keyword parameters

### DIFF
--- a/lib/handlebars/engine.rb
+++ b/lib/handlebars/engine.rb
@@ -68,9 +68,12 @@ module Handlebars
     # @yieldparam arguments [Object] the arguments (optional)
     # @yieldparam options [Hash] the options hash (optional)
     # @see https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerhelper-name-helper
-    def register_helper(name, &block)
-      attach(name, &block)
-      call(:registerHelper, [name.to_s, name.to_sym], eval: true)
+    def register_helper(name = nil, **helpers, &block)
+      helpers[name] = block if name
+      helpers.each do |n, f|
+        attach(n, &f)
+        call(:registerHelper, [n.to_s, n.to_sym], eval: true)
+      end
     end
 
     # Unregisters a previously registered helper.

--- a/spec/handlebars/engine_spec.rb
+++ b/spec/handlebars/engine_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Handlebars::Engine do
 
   describe "#register_helper" do
     let(:name) { :helper }
-    let(:function) { ->(ctx, *args, opts) {} }
+    let(:function) { ->(_ctx, *_args, _opts) { rendered } }
     let(:template) { "{{#{name} name name=name}}" }
 
     before do
@@ -158,7 +158,27 @@ RSpec.describe Handlebars::Engine do
       expect(engine).to respond_to(:register_helper)
     end
 
-    describe "rendering" do
+    context "with positional parameters" do
+      before do
+        engine.register_helper(name, &function)
+      end
+
+      describe "rendering" do
+        include_examples "rendering"
+      end
+    end
+
+    context "with keyword parameters" do
+      before do
+        engine.register_helper(name => function)
+      end
+
+      describe "rendering" do
+        include_examples "rendering"
+      end
+    end
+
+    describe "parameters" do
       describe "the first parameter" do
         it "is the context" do
           render_context.transform_keys!(&:to_s)


### PR DESCRIPTION
This updates the `register_helper` method to accept keyword parameters
for defining multiple helpers in one call:

```ruby
register_helper(name1 => fn1, name2 => fn2)
```