### PR TITLE
register_helper: accept javascript function as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ See https://handlebarsjs.com/guide/#custom-helpers.
 
 ### Block Helpers
 
+Block helpers make it possible to define custom iterators and other
+functionality that can invoke the passed block with a new context.
+
+Currently, there is a limitation with the underlying JavaScript engine: it does
+not allow for reentrant calls from within attached Ruby functions: see
+[MiniRacer#225](https://github.com/rubyjs/mini_racer/issues/225). Thus, the
+block function returned to the helper (in `options.fn`) cannot be  invoked.
+
+Thus, for block helpers, a string of JavaScript must define the helper function:
+```ruby
+handlebars = Handlebars::Engine.new
+handlebars.register_helper(map: <<~JS)
+  function(...args) {
+    const ctx = this;
+    const opts = args.pop();
+    const items = args[0];
+    const separator = args[1];
+    const mapped = items.map((item) => opts.fn(item));
+    return mapped.join(separator);
+  }
+JS
+template = handlebars.compile("{{#map items '|'}}'{{this}}'{{/map}}")
+template.call({ items: [1, 2, 3] })
+# => "'1'|2'|'3'"
+```
+
 See https://handlebarsjs.com/guide/#block-helpers.
 
 ### Partials

--- a/lib/handlebars/engine.rb
+++ b/lib/handlebars/engine.rb
@@ -63,16 +63,28 @@ module Handlebars
 
     # Registers helpers accessible by any template in the environment.
     #
+    # The function can be either a proc or a string:
+    # * When the function is a proc, it can be either passed in as a normal
+    #   parameter or as a block.
+    # * When the function is a string, it is interpreted as a JavaScript
+    #   function.
+    #
     # @param name [String, Symbol] the name of the helper
+    # @param function [Proc, String] the helper function
     # @yieldparam context [Hash] the current context
     # @yieldparam arguments [Object] the arguments (optional)
     # @yieldparam options [Hash] the options hash (optional)
     # @see https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerhelper-name-helper
-    def register_helper(name = nil, **helpers, &block)
-      helpers[name] = block if name
+    def register_helper(name = nil, function = nil, **helpers, &block)
+      helpers[name] = block || function if name
       helpers.each do |n, f|
-        attach(n, &f)
-        call(:registerHelper, [n.to_s, n.to_sym], eval: true)
+        case f
+        when Proc
+          attach(n, &f)
+          evaluate("registerHelper('#{n}', #{n})")
+        when String, Symbol
+          evaluate("Handlebars.registerHelper('#{n}', #{f})")
+        end
       end
     end
 
@@ -217,14 +229,7 @@ module Handlebars
     end
 
     def js_args(args)
-      args.map { |arg|
-        case arg
-        when Symbol
-          arg
-        else
-          JSON.generate(arg)
-        end
-      }
+      args.map { |arg| JSON.generate(arg) }
     end
   end
 end


### PR DESCRIPTION
This updates `register_helper` to accept a string of JavaScript source code
which will be interpreted as the helper function.