### PR TITLE
[#14] engine: return `Function` object instead of lambda

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,6 +154,9 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 8
 
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+
 Style/BlockDelimiters:
   EnforcedStyle: semantic
   AllowBracesOnProceduralOneLiners: true

--- a/lib/handlebars/engine.rb
+++ b/lib/handlebars/engine.rb
@@ -4,6 +4,7 @@ require "handlebars/source"
 require "json"
 require "mini_racer"
 require "securerandom"
+require_relative "engine/function"
 require_relative "engine/version"
 
 module Handlebars
@@ -199,9 +200,7 @@ module Handlebars
       result = evaluate(code)
 
       if var && result.is_a?(MiniRacer::JavaScriptFunction)
-        result = ->(*a) { @context.call(var, *a) }
-        finalizer = ->(*) { evaluate("delete #{var}") }
-        ObjectSpace.define_finalizer(result, finalizer)
+        result = Function.new(@context, var)
       end
 
       result

--- a/lib/handlebars/engine/function.rb
+++ b/lib/handlebars/engine/function.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Handlebars
+  class Engine
+    # A proxy for a JavaScript function defined in the context.
+    class Function
+      def initialize(context, name)
+        @context = context
+        @name = name
+        ObjectSpace.define_finalizer(self, self.class.finalizer(context, name))
+      end
+
+      def call(*args)
+        @context.call(@name, *args)
+      end
+
+      def self.finalizer(context, name)
+        proc {
+          context.eval("delete #{name}")
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the result of the JavaScript call is a function (e.g. `compile`),
create a new `Function` class instance instead of using a lambda.

This fixes an issue where the object finalizer was causing the Ruby VM
to hold on to the engine's instance.

Fixes #14