### PR TITLE
Version 0.3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,6 +154,9 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 8
 
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+
 Style/BlockDelimiters:
   EnforcedStyle: semantic
   AllowBracesOnProceduralOneLiners: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2022-02-17
+
+### Changed
+- `engine`: fixed issue with memory leak ([#15](https://github.com/gi/handlebars-ruby/pull/15))
+
 ## [0.3.1] - 2022-02-04
 
 ### Added

--- a/lib/handlebars/engine.rb
+++ b/lib/handlebars/engine.rb
@@ -4,6 +4,7 @@ require "handlebars/source"
 require "json"
 require "mini_racer"
 require "securerandom"
+require_relative "engine/function"
 require_relative "engine/version"
 
 module Handlebars
@@ -199,9 +200,7 @@ module Handlebars
       result = evaluate(code)
 
       if var && result.is_a?(MiniRacer::JavaScriptFunction)
-        result = ->(*a) { @context.call(var, *a) }
-        finalizer = ->(*) { evaluate("delete #{var}") }
-        ObjectSpace.define_finalizer(result, finalizer)
+        result = Function.new(@context, var)
       end
 
       result

--- a/lib/handlebars/engine/function.rb
+++ b/lib/handlebars/engine/function.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Handlebars
+  class Engine
+    # A proxy for a JavaScript function defined in the context.
+    class Function
+      def initialize(context, name)
+        @context = context
+        @name = name
+        ObjectSpace.define_finalizer(self, self.class.finalizer(context, name))
+      end
+
+      def call(*args)
+        @context.call(@name, *args)
+      end
+
+      def self.finalizer(context, name)
+        proc {
+          context.eval("delete #{name}")
+        }
+      end
+    end
+  end
+end

--- a/lib/handlebars/engine/function.rb
+++ b/lib/handlebars/engine/function.rb
@@ -16,7 +16,10 @@ module Handlebars
 
       def self.finalizer(context, name)
         proc {
-          context.eval("delete #{name}")
+          begin
+            context.eval("delete #{name}")
+          rescue ThreadError # rubocop:disable Lint/SuppressedException
+          end
         }
       end
     end

--- a/lib/handlebars/engine/version.rb
+++ b/lib/handlebars/engine/version.rb
@@ -2,6 +2,6 @@
 
 module Handlebars
   class Engine
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
### Changed
- `engine`: fixed issue with memory leak ([#15](https://github.com/gi/handlebars-ruby/pull/15))