### PR TITLE
ci: update runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,11 @@ jobs:
     strategy:
       matrix:
         os:
+          - macos-14
           - macos-latest
+          - ubuntu-22.04
           - ubuntu-latest
         ruby:
-          - ruby-3.0
           - ruby-3.1
           - ruby-3.2
           - ruby-3.3


### PR DESCRIPTION
This updates the os and ruby versions on which to test:
* include latest two os versions: mac + ubuntu
* include latest four ruby versions